### PR TITLE
Добавлен конфиг для автодеплоя и конфиг для веб-сервера

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,62 @@
+pipeline {
+  agent {
+    docker {
+      image 'cimmwolf/vistro:3'
+      args '-u root:root'
+    }
+  }
+  environment {
+    BuildEnv      = "${env.TAG_NAME && env.TAG_NAME ==~ /v?\d+\.\d+\.\d+.*/ ? "production" : "sandbox"}"
+    ServerIp      = "78.155.197.111"
+    BasePath      = "/var/www/${BuildEnv}/hema-league.ru"
+    RemoteMachine = "deploy@${ServerIp}"
+    ReleaseDate   = """${sh(
+                            returnStdout: true,
+                            script: 'echo $(date "+%Y%m%d%H%M%S")'
+                        ).trim()}"""
+    ReleasePath   = "${BasePath}/releases/${ReleaseDate}"
+  }
+  stages {
+    stage('Build') {
+      steps {
+        sh 'mkdir ~/.ssh && ssh-keyscan ${ServerIp} >> ~/.ssh/known_hosts'
+        sh 'yarn build'
+      }
+    }
+    stage('Prepare for prod') {
+      when {
+        environment name: 'BuildEnv', value: 'production'
+      }
+      steps {
+        sh 'sed -i -e "s/listen 8000/listen 443/g" nginx.conf'
+        sh 'sed -i -e "s/listen 8080/listen 80/g" nginx.conf'
+        sh 'sed -i -e "s:/sandbox/:/production/:g" nginx.conf'
+      }
+    }
+    stage('Deploy') {
+      steps {
+        sshagent(credentials: ['c98cafdc-9af0-4637-b970-6cc7f2305852']) {
+          sh "ssh $RemoteMachine mkdir -p ${BasePath}/releases ${BasePath}/logs ${BasePath}/shared"
+
+          sh "rsync -rlzv --delete --link-dest=${BasePath}/current ./dist/ ${RemoteMachine}:${ReleasePath}"
+          sh "scp nginx.conf ${RemoteMachine}:${BasePath}"
+        }
+      }
+    }
+    stage('Clean & restart') {
+      steps {
+        sshagent(credentials: ['c98cafdc-9af0-4637-b970-6cc7f2305852']) {
+          sh "ssh $RemoteMachine ln -vfn -s ${ReleasePath} ${BasePath}/current"
+          sh "ssh $RemoteMachine 'cd ${BasePath}/releases && ls -1r | tail -n +2 | xargs rm -rf'"
+          sh "ssh $RemoteMachine 'sudo nginx -t && sudo service nginx restart'"
+        }
+      }
+    }
+  }
+  post {
+    always {
+      sh "chown -R ${JENKINS_UID}:${JENKINS_GID} ./"
+      cleanWs()
+    }
+  }
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,47 @@
+server {
+	server_name hema-league.ru;
+	listen 8000 ssl;
+	http2 on;
+
+	ssl_certificate "/etc/letsencrypt/live/hema-league.ru/fullchain.pem";
+	ssl_certificate_key "/etc/letsencrypt/live/hema-league.ru/privkey.pem";
+
+	disable_symlinks if_not_owner from=$root_path;
+	index index.html;
+	root $root_path;
+	set $root_path /var/www/sandbox/hema-league.ru/current;
+	access_log /var/www/sandbox/hema-league.ru/logs/access.log;
+	error_log /var/www/sandbox/hema-league.ru/logs/error.log notice;
+
+	location / {
+	    try_files $uri $uri/ /index.html;
+    }
+}
+
+server {
+	server_name hema-league.ru www.hema-league.ru;
+	listen 8080;
+
+	location /.well-known {
+		root /var/www;
+	}
+	location / {
+		return 301 https://hema-league.ru$request_uri;
+	}
+}
+
+server {
+	server_name www.hema-league.ru;
+	listen 8000 ssl;
+	http2 on;
+
+	ssl_certificate "/etc/letsencrypt/live/hema-league.ru/fullchain.pem";
+	ssl_certificate_key "/etc/letsencrypt/live/hema-league.ru/privkey.pem";
+
+	location /.well-known {
+		root /var/www;
+	}
+	location / {
+		return 301 https://hema-league.ru$request_uri;
+	}
+}


### PR DESCRIPTION
Для полноценной работы автодеплоя, нужно настроить вебхук:
1. Зайди в настройки репозитория, в вебхуки
<img width="325" alt="image" src="https://github.com/user-attachments/assets/20282b2e-3a3f-4e51-a1de-28ed4c52e49b" />

2. Нажми кнопку "Добавить вебхук"
<img width="810" alt="image" src="https://github.com/user-attachments/assets/edb8d46f-378d-4f20-bc92-4034f8d97062" />

3. Укажи адрес вебхука https://jenkins.vistro.ru/github-webhook/ и поставь отметку Send me everything
<img width="786" alt="image" src="https://github.com/user-attachments/assets/6ec79e06-d0e1-4c81-b25b-9021243aecc3" />


Автоматическая публикация проекта настроена следующим образом:
• При любом пуше в репозиторий запускается сборка, и через несколько минут проект становится доступен по адресу: https://hema-league.ru:8000
Этот адрес очень удобен для демонстрации текущих изменений — например, заказчикам, до основной публикации.
• Основная публикация на продакшен происходит вручную — при добавлении тега к нужному коммиту. Публикуется именно тот коммит, на который указывает тег.
• Формат тега — дата, например: 2025.6.29

